### PR TITLE
Update instructions for using Entra registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Instructions for creating and deploying a new App Configuration Policy can be fo
 2. This app's bundle ID is `Intune.chatr`. Make sure you update this bundle ID to match the app registration. The bundle ID can be found by selecting the project file in the Xcode project explorer, selecting the chatr target, and selecting the "General" tab.
 3. In the Info.plist file, update the values for `ADALClientId` and `ADALRedirectUri` under IntuneMAMSettings dictionary to match the client ID and redirect URI from your app registration. The redirect URI should be in the format `msauth.<bundle-id>://auth`. 
 4. If your app registration was configured as a single-tenant app, you will also need to add the `ADALAuthority` value to the Info.plist file under IntuneMAMSettings. This can be skipped for multi-tenant app registrations.
-5. The redirect URI also needs to be added to the `URL Schemes` under `URL Types` in the Info.plist file.
+5. The redirect URI scheme which is of the format `msauth.<bundle-id>` needs to be added to the `URL Schemes` under `URL Types` in the Info.plist file.
 
 ### Step 5: Launch the App & Sign-In
 Chatr should now be properly configured with Intune. When prompted to sign in, use one of the users in the group used in Step 2 or Step 3. 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,13 @@ Instructions for creating and deploying a new App Configuration Policy can be fo
 1. Enter the Bundle ID of your app and click **OK**. The Chatr bundle ID can be found by selecting the project file in the Xcode project explorer, selecting the chatr target, and selecting the "General" tab. This app's Package ID is `Intune.chatr`.
 1. Click the **Configuration settings** button in the "Add configuration policy" pane and set the key-value pair configuration you would like to apply to a user group for your app. For intance, to change the messaging group name on the Chat Page of the Chatr sample app to "Intune", you can create a configuration where the key is "GroupName" and the value is "Intune".
 1. Once you have added the key-value pair configuration click **OK** at the bottom of the "Configuration" pane and then click **Add** at the bottom of the "Add configuration policy" pane. Your app should now appear in the "App configuration policies" pane.
-    
-### Step 4: Launch the App & Sign-In
+
+### Step 4: Register the App with Microsoft Entra ID
+1. You'll need to configure an app registration in Microsoft Entra ID and specify the client ID and redirect URI that the Intune SDK should use. Instructions for creating an app registration can be found [here](https://learn.microsoft.com/azure/active-directory/develop/quickstart-register-app).
+2. This app's bundle ID is `Intune.chatr`. Make sure you update this bundle ID to match the app registration. The bundle ID can be found by selecting the project file in the Xcode project explorer, selecting the chatr target, and selecting the "General" tab.
+3. In the Info.plist file, update the values for `AADClientID` and `AADRedirectURI` under IntuneMAMSettings dictionary to match the client ID and redirect URI from your app registration. The redirect URI should be in the format `msauth.<bundle-id>://auth`.
+
+### Step 5: Launch the App & Sign-In
 Chatr should now be properly configured with Intune. When prompted to sign in, use one of the users in the group used in Step 2 or Step 3. 
 ## Relevant Files
 - `Chatr/LoginPage.swift` contains logic for authenticating and enrolling the user with Intune.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Instructions for creating and deploying a new App Configuration Policy can be fo
 2. This app's bundle ID is `Intune.chatr`. Make sure you update this bundle ID to match the app registration. The bundle ID can be found by selecting the project file in the Xcode project explorer, selecting the chatr target, and selecting the "General" tab.
 3. In the Info.plist file, update the values for `ADALClientId` and `ADALRedirectUri` under IntuneMAMSettings dictionary to match the client ID and redirect URI from your app registration. The redirect URI should be in the format `msauth.<bundle-id>://auth`. 
 4. If your app registration was configured as a single-tenant app, you will also need to add the `ADALAuthority` value to the Info.plist file under IntuneMAMSettings. This can be skipped for multi-tenant app registrations.
+5. The redirect URI also needs to be added to the `URL Schemes` under `URL Types` in the Info.plist file.
 
 ### Step 5: Launch the App & Sign-In
 Chatr should now be properly configured with Intune. When prompted to sign in, use one of the users in the group used in Step 2 or Step 3. 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Instructions for creating and deploying a new App Configuration Policy can be fo
 ### Step 4: Register the App with Microsoft Entra ID
 1. You'll need to configure an app registration in Microsoft Entra ID and specify the client ID and redirect URI that the Intune SDK should use. Instructions for creating an app registration can be found [here](https://learn.microsoft.com/azure/active-directory/develop/quickstart-register-app).
 2. This app's bundle ID is `Intune.chatr`. Make sure you update this bundle ID to match the app registration. The bundle ID can be found by selecting the project file in the Xcode project explorer, selecting the chatr target, and selecting the "General" tab.
-3. In the Info.plist file, update the values for `AADClientID` and `AADRedirectURI` under IntuneMAMSettings dictionary to match the client ID and redirect URI from your app registration. The redirect URI should be in the format `msauth.<bundle-id>://auth`.
+3. In the Info.plist file, update the values for `ADALClientId` and `ADALRedirectUri` under IntuneMAMSettings dictionary to match the client ID and redirect URI from your app registration. The redirect URI should be in the format `msauth.<bundle-id>://auth`. 
+4. If your app registration was configured as a single-tenant app, you will also need to add the `ADALAuthority` value to the Info.plist file under IntuneMAMSettings. This can be skipped for multi-tenant app registrations.
 
 ### Step 5: Launch the App & Sign-In
 Chatr should now be properly configured with Intune. When prompted to sign in, use one of the users in the group used in Step 2 or Step 3. 

--- a/chatr/Info.plist
+++ b/chatr/Info.plist
@@ -56,6 +56,8 @@
 		<string>wandera</string>
 		<string>https-intunemam</string>
 		<string>http-intunemam</string>
+		<string>msauthv2</string>
+		<string>msauthv3</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>

--- a/chatr/Info.plist
+++ b/chatr/Info.plist
@@ -29,7 +29,7 @@
 			<array>
 				<string>chatr</string>
 				<string>chatr-intunemam</string>
-				<string>msauth.com.microsoft.intunemam</string>
+				<string>msauth.Intune.chatr</string>
 			</array>
 		</dict>
 	</array>

--- a/chatr/Info.plist
+++ b/chatr/Info.plist
@@ -63,6 +63,13 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<key>IntuneMAMSettings</key>
+	<dict>
+		<key>ADALClientId</key>
+		<string>Insert_Entra_Client_ID</string>
+		<key>ADALRedirectUri</key>
+		<string>Insert_Entra_Redirect_URI</string>
+	</dict>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
Intune SDK now requires apps to have a valid Entra registration in order to authenticate against the MSAL library. Updating the app to match this behavior. 